### PR TITLE
fix: Adding prettierrc and mutation observer

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "trailingComma": "es5",
+  "semi": true,
+  "singleQuote": true
+}

--- a/index.js
+++ b/index.js
@@ -306,13 +306,17 @@ if (
   // if the grep test toggle is checked, do not show checkboxes on each runnable
   window.top?.document.querySelectorAll('#grepTestToggle:checked').length === 0
 ) {
-  window.top?.document.addEventListener('click', () => {
+  // watching for changes to DOM structure
+  MutationObserver = window.MutationObserver;
+
+  var observer = new MutationObserver(function () {
+    // fired when a mutation occurs
     addGrepButtons();
   });
-  window.top?.document.addEventListener('dblclick', () => {
-    addGrepButtons();
-  });
-  window.top?.document.addEventListener('keypress', () => {
-    addGrepButtons();
+
+  // defining the window.top?.document to be observed by the observer
+  observer.observe(window.top?.document, {
+    subtree: true,
+    attributes: true,
   });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-grep-boxes",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-grep-boxes",
-      "version": "1.0.3",
+      "version": "1.0.4",
       "license": "MIT",
       "devDependencies": {
         "@bahmutov/cy-grep": "^1.9.17",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-grep-boxes",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Cypress plugin that allows user to run specific tests in open mode.",
   "main": "./index.js",
   "keywords": [


### PR DESCRIPTION
Follow-up to #3 with a different and more effective approach to observing mutations in the Cypress Test Runner when a user toggles suites and checkboxes had disappeared.

Instead of various `addEventListeners` to trigger grep boxes to be added back after toggling suites, this effort introduces  `MutationObserver` (https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to watch for changes in DOM tree.