### PR TITLE
feat: Add capability to hide and show on `hideSpecTags` env variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,9 @@ npx cypress open --env grepTags=@skip
 
 The `cypress-plugin-grep-boxes` plugin (new in v2.0.0) displays all available `effectiveTestTags` in the Cypress Test Runner for each test.
 
-If for any reason you'd like to exclude specific tags from being added to the Cypress Test Runner, use the environment variable `hideSpecTags` set to an array of tags you do not want to be displayed in the Cypress Test Runner.
+If for any reason you'd like to exclude tags from being displayed in the Cypress Test Runner, use the environment variable `hideSpecTags` set to an array of tags you do not want to be displayed in the Cypress Test Runner.
+
+### Hide specific tags
 
 Example:
 
@@ -122,7 +124,35 @@ Example:
 }
 ```
 
-The example above would not add any tags to Cypress Test Runner titled `@smoke` and `@sanity`.
+The example above would hide `@smoke` and `@sanity` tags, but show all other tags, in the Cypress Test Runner.
+
+### Hide all tags
+
+If you'd like to exclude all tags from being displayed in the Cypress Test Runner, use the following:
+
+```json
+{
+  "env": {
+    "hideSpecTags": ["*"]
+  }
+}
+```
+
+The example above would not display ANY tags to Cypress Test Runner.
+
+### Hide all tags EXCEPT specified
+
+If you'd like to ONLY display a specific subset of tags in the Cypress Test Runner, prefix tags you'd like to see displayed with `+`:
+
+```json
+{
+  "env": {
+    "hideSpecTags": ["*", "+@smoke", "+@sanity"]
+  }
+}
+```
+
+The example above would hide all tags EXCEPT `@smoke` and `@sanity` tags in the Cypress Test Runner.
 
 ## disableInitialAutoRun
 

--- a/index.js
+++ b/index.js
@@ -431,7 +431,7 @@ function getTagsForTitle(title, fullTagsObj) {
     }
   }
 
-  // Apply logic
+  // Apply tag display filtering logic
   return allTags.filter((tag) => {
     if (includeSet.has(tag)) return true;
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "cypress-plugin-grep-boxes",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "cypress-plugin-grep-boxes",
-      "version": "2.2.0",
+      "version": "2.3.0",
       "license": "MIT",
       "devDependencies": {
         "@bahmutov/cy-grep": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cypress-plugin-grep-boxes",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "Cypress plugin that allows user to run specific tests in open mode.",
   "main": "./index.js",
   "keywords": [


### PR DESCRIPTION
Relates to: https://github.com/dennisbergevin/cypress-plugin-grep-boxes/issues/17

In `cypress-plugin-grep-boxes` v2.2.0, the `hideSpecTags` environment variable was added as a method of hiding specific tags passed as an array. 

This effort adds a few more capabilities to `hideSpecTags`:

### Hide specific tags

Example:

```json
{
  "env": {
    "hideSpecTags": ["@smoke", "@sanity"]
  }
}
```

The example above would hide `@smoke` and `@sanity` tags, but show all other tags, in the Cypress Test Runner.

### Hide all tags

If you'd like to exclude all tags from being displayed in the Cypress Test Runner, use the following:

```json
{
  "env": {
    "hideSpecTags": ["*"]
  }
}
```

The example above would not display ANY tags to Cypress Test Runner.

### Hide all tags EXCEPT specified

If you'd like to ONLY display a specific subset of tags in the Cypress Test Runner, prefix tags you'd like to see displayed with `+`:

```json
{
  "env": {
    "hideSpecTags": ["*", "+@smoke", "+@sanity"]
  }
}
```

The example above would hide all tags EXCEPT `@smoke` and `@sanity` tags in the Cypress Test Runner.